### PR TITLE
Store output PDF as build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,8 @@ jobs:
         with:
           root_file: main.tex
           post_compile: "if [[ $(grep -ic overfull *.log) != 0 ]]; then echo 'Margin overrun detected; failing...' && exit 1; fi"
+      - name: Store PDF
+        uses: actions/upload-artifact@v2
+        with:
+          name: Output PDF
+          path: main.pdf

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Release versions are posted to the [IACR preprint archive](https://eprint.iacr.o
 ## Testing
 
 Testing consists of a workflow in this repository that builds the paper and checks for errors and certain warnings.
+You can view the resulting PDF as a build artifact.
 
 ![Build status](../../actions/workflows/build.yml/badge.svg)


### PR DESCRIPTION
After CI runs, stores the resulting PDF as a build artifact.