### PR TITLE
Use wildcard in build artifact path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Output PDF
-          path: main.pdf
+          path: ./*.pdf


### PR DESCRIPTION
Uses a path wildcard to save all output PDF files as build artifacts.