### PR TITLE
Use key-committing authenticated encryption

### DIFF
--- a/main.bib
+++ b/main.bib
@@ -28,7 +28,7 @@ series = {SEC'14}
     title        = {Scalable Multi-party Computation for zk-{SNARK} Parameters in the Random Beacon Model},
     howpublished = {Cryptology ePrint Archive, Report 2017/1050},
     year         = {2017},
-    note         = {\url{https://ia.cr/2017/1050}},
+    url         = {https://ia.cr/2017/1050},
 }
 
 @InProceedings{mw,
@@ -51,7 +51,7 @@ isbn="978-3-030-17653-2"
     title        = {Lelantus: A New Design for Anonymous and Confidential Cryptocurrencies},
     howpublished = {Cryptology ePrint Archive, Report 2019/373},
     year         = {2019},
-    note         = {\url{https://ia.cr/2019/373}},
+    url         = {https://ia.cr/2019/373},
 }
 
 @misc{lmw,
@@ -59,14 +59,14 @@ isbn="978-3-030-17653-2"
     title        = {Lelantus-{CLA}},
     howpublished = {Cryptology ePrint Archive, Report 2021/1036},
     year         = {2021},
-    note         = {\url{https://ia.cr/2021/1036}},
+    url         = {https://ia.cr/2021/1036},
 }
 
 @misc{zcash,
 author = {Daira Hopwood and Sean Bowe and Taylor Hornby and Nathan Wilcox},
 title = {Zcash Protocol Specification},
 year = {2021},
-note = {\url{https://github.com/zcash/zips/blob/master/protocol/protocol.pdf}},
+url = {https://github.com/zcash/zips/blob/master/protocol/protocol.pdf},
 }
 
 @InProceedings{groth,
@@ -149,7 +149,6 @@ year = {2019},
 isbn = {9781450367479},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://doi.org/10.1145/3319535.3345655},
 doi = {10.1145/3319535.3345655},
 booktitle = {Proceedings of the 2019 ACM SIGSAC Conference on Computer and Communications Security},
 pages = {31–48},
@@ -178,7 +177,7 @@ series = {CCS '19}
     title        = {Bulletproofs+: Shorter Proofs for Privacy-Enhanced Distributed Ledger},
     howpublished = {Cryptology ePrint Archive, Report 2020/735},
     year         = {2020},
-    note         = {\url{https://ia.cr/2020/735}},
+    url         = {https://ia.cr/2020/735},
 }
 
 @INPROCEEDINGS{zerocash,
@@ -198,7 +197,7 @@ series = {CCS '19}
     title        = {Concise Linkable Ring Signatures and Forgery Against Adversarial Keys},
     howpublished = {Cryptology ePrint Archive, Report 2019/654},
     year         = {2019},
-    note         = {\url{https://ia.cr/2019/654}},
+    url         = {https://ia.cr/2019/654},
 }
 
 @techreport{chachapoly,
@@ -213,7 +212,6 @@ series = {CCS '19}
   publisher = {RFC Editor},
   institution = {RFC Editor},
   url = {http://www.rfc-editor.org/rfc/rfc7539.txt},
-  note = {\url{http://www.rfc-editor.org/rfc/rfc7539.txt}},
 }
 
 @article{pippenger,
@@ -237,8 +235,7 @@ series = {CCS '19}
 
 @article{schnorr,
 author = {Gregory Neven and Nigel P. Smart and Bogdan Warinschi},
-doi = {doi:10.1515/JMC.2009.004},
-url = {https://doi.org/10.1515/JMC.2009.004},
+doi = {10.1515/JMC.2009.004},
 title = {Hash function requirements for {S}chnorr signatures},
 journal = {Journal of Mathematical Cryptology},
 number = {1},
@@ -252,7 +249,7 @@ pages = {69--87}
     title        = {{FROST}: Flexible Round-Optimized {S}chnorr Threshold Signatures},
     howpublished = {Cryptology ePrint Archive, Report 2020/852},
     year         = {2020},
-    note         = {\url{https://ia.cr/2020/852}},
+    url         = {https://ia.cr/2020/852},
 }
 
 @misc{schnorrwithschnorr,
@@ -262,7 +259,7 @@ pages = {69--87}
     title        = {How to Prove {S}chnorr Assuming {S}chnorr: Security of Multi- and Threshold Signatures},
     howpublished = {Cryptology ePrint Archive, Report 2021/1375},
     year         = {2021},
-    note         = {\url{https://ia.cr/2021/1375}},
+    url         = {https://ia.cr/2021/1375},
 }
 
 @InProceedings{keyprivacy,
@@ -327,7 +324,6 @@ year = {2019},
 isbn = {9781450367479},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://doi.org/10.1145/3319535.3354200},
 doi = {10.1145/3319535.3354200},
 booktitle = {Proceedings of the 2019 ACM SIGSAC Conference on Computer and Communications Security},
 pages = {567–584},
@@ -342,7 +338,6 @@ series = {CCS '19}
       title = {Stronger Security for Non-Interactive Threshold Signatures: {BLS} and {FROST}},
       howpublished = {Cryptology ePrint Archive, Paper 2022/833},
       year = {2022},
-      note = {\url{https://eprint.iacr.org/2022/833}},
       url = {https://eprint.iacr.org/2022/833}
 }
 

--- a/main.bib
+++ b/main.bib
@@ -259,7 +259,7 @@ pages = {69--87}
     author       = {Elizabeth Crites and
 		    Chelsea Komlo and
 		    Mary Maller},
-    title        = {How to Prove Schnorr Assuming Schnorr: Security of Multi- and Threshold Signatures},
+    title        = {How to Prove {S}chnorr Assuming {S}chnorr: Security of Multi- and Threshold Signatures},
     howpublished = {Cryptology ePrint Archive, Report 2021/1375},
     year         = {2021},
     note         = {\url{https://ia.cr/2021/1375}},
@@ -344,4 +344,17 @@ series = {CCS '19}
       year = {2022},
       note = {\url{https://eprint.iacr.org/2022/833}},
       url = {https://eprint.iacr.org/2022/833}
+}
+
+@inproceedings{key_commitment,
+title = {How to Abuse and Fix Authenticated Encryption Without Key Commitment},
+author={Albertini, Ange and Duong, Thai and Gueron, Shay and K{\"o}lbl, Stefan and Luykx, Atul and Schmieg, Sophie},
+booktitle = {31st USENIX Security Symposium (USENIX Security 22)},
+year = {2022},
+isbn = {978-1-939133-31-1},
+address = {Boston, MA},
+pages = {3291--3308},
+url = {https://www.usenix.org/conference/usenixsecurity22/presentation/albertini},
+publisher = {USENIX Association},
+month = aug,
 }

--- a/main.tex
+++ b/main.tex
@@ -137,10 +137,12 @@ We require that the proving system be complete, special honest-verifier zero kno
 We present an instantiation of such a proving system in Appendix \ref{app:parallel}.
 
 
-\subsection{Authenticated Encryption Scheme}
+\subsection{Key-Committing Authenticated Encryption Scheme}
 
-We require the use of an authenticated symmetric encryption with associated data (AEAD) scheme.
+We require the use of an authenticated symmetric encryption with associated data (AEAD) scheme that commits to keys.
 In the context of the Spark protocol, this construction is used to encrypt value, memo, and other data for use by the recipient of a transaction.
+Note that in general, AEAD schemes need not commit to keys; because Spark payment proofs require this property, we require it in the overall protocol.
+It is possible to generically extend an AEAD scheme using the technique of \cite{key_commitment} in a flexible manner by including a commitment to the key as part of the ciphertext, and by checking this commitment during authentication; we assume this approach when describing the algorithms here.
 
 Let $pp_{\text{aead}}$ be the public parameters for such a construction.
 The construction itself is a tuple of algorithms $(\func{AEADKeyGen},\func{AEADEncrypt},\func{AEADDecrypt})$.
@@ -645,7 +647,7 @@ By providing a payment proof, anyone can verify that the specified coin was dest
 
 It is instructive to examine the efficiency of spend transactions in size, generation complexity, and verification complexity.
 In addition to our previous notation for parameters, let $v_{\text{max}} = 2^{64}$, so coin values and fees can be represented by $8$-byte unsigned integers.
-Further, suppose coin memos are fixed at $M$ bytes in length, diversifiers are restricted to $I$ bytes in length, with a $16$-byte authentication tag; this is the case for the ChaCha20-Poly1305 authenticated symmetric encryption construction, for example \cite{chachapoly}.
+Further, suppose coin memos are fixed at $M$ bytes in length, diversifiers are restricted to $I$ bytes in length, with a $16$-byte authentication tag and $32$-byte key commitment; this is the case for the ChaCha20-Poly1305 authenticated symmetric encryption construction (modified using the technique in \cite{key_commitment}), for example \cite{chachapoly}.
 Additionally, the arguments in \cite{schnorr} imply that Schnorr representation proofs can use truncated hash outputs for reduced proof size.
 Transaction size data for specific component instantiations is given in Table \ref{table:size}, where we consider the size in terms of group elements, field elements, and other data.
 Note that we do not include input ambiguity set references in this data, as this depends on implementation-specific selection and representation criteria.
@@ -671,7 +673,7 @@ Note that we do not include input ambiguity set references in this data, as this
         \multicolumn{5}{|c|}{Output data ($t$ coins)} \\
         \hline
         $(S,K,C)$ & & $3t$ & & \\
-        $\overline{r}$ & ChaCha20-Poly1305 & & & $(8 + M + I + 16)t$ \\
+        $\overline{r}$ & ChaCha20-Poly1305 & & & $(8 + M + I + 48)t$ \\
         \hline
     \end{tabular}
 \end{table}


### PR DESCRIPTION
Uses key-committing authenticated encryption required for a payment proof security argument. Fixes reference formatting.